### PR TITLE
Use Firestore emulator for local development

### DIFF
--- a/public/js/firebase.js
+++ b/public/js/firebase.js
@@ -1,6 +1,6 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.4.0/firebase-app.js";
 import { getAuth } from "https://www.gstatic.com/firebasejs/10.4.0/firebase-auth.js";
-import { getFirestore } from "https://www.gstatic.com/firebasejs/10.4.0/firebase-firestore.js";
+import { getFirestore, connectFirestoreEmulator } from "https://www.gstatic.com/firebasejs/10.4.0/firebase-firestore.js";
 
 // TODO: replace with your Firebase project configuration
 const firebaseConfig = {
@@ -15,3 +15,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+
+if (typeof window !== "undefined" && window.location.hostname === "localhost") {
+  connectFirestoreEmulator(db, "localhost", 8080);
+}


### PR DESCRIPTION
## Summary
- Use Firestore emulator when running on localhost to avoid backend connection errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adffc79cd0832ea27aafceb21e5639