### PR TITLE
Fix dashboard role lookup to restore module display

### DIFF
--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+
+const onAuthStateChanged = jest.fn();
+const signOut = jest.fn();
+jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.4.0/firebase-auth.js', () => ({
+  onAuthStateChanged,
+  signOut
+}));
+
+const getDoc = jest.fn();
+const doc = jest.fn();
+jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.4.0/firebase-firestore.js', () => ({
+  getDoc,
+  doc
+}));
+
+jest.unstable_mockModule('../public/js/firebase.js', () => ({
+  auth: {},
+  db: {}
+}), { virtual: true });
+
+jest.unstable_mockModule('../public/js/toast.js', () => ({ showToast: jest.fn() }), { virtual: true });
+
+test('renderDashboard handles case-insensitive role', async () => {
+  document.body.innerHTML = '<nav id="modules-nav"></nav>';
+  onAuthStateChanged.mockImplementation((auth, cb) => cb({ uid: 'u1' }));
+  getDoc.mockResolvedValue({ exists: () => true, data: () => ({ role: 'Admin' }) });
+
+  await import('../public/js/check-auth.js');
+
+  const items = document.querySelectorAll('#modules-nav li');
+  expect(items.length).toBeGreaterThan(0);
+});

--- a/public/js/check-auth.js
+++ b/public/js/check-auth.js
@@ -32,7 +32,9 @@ const ROLE_PERMISSIONS = {
 async function getUserRole(uid) {
   try {
     const snap = await getDoc(doc(db, 'users', uid));
-    return snap.exists() ? snap.data().role : null;
+    if (!snap.exists()) return null;
+    const role = snap.data().role;
+    return typeof role === 'string' ? role.toLowerCase() : null;
   } catch {
     showToast('Erro ao carregar permissões', 'error');
     return null;


### PR DESCRIPTION
## Summary
- normalize user roles when retrieving permissions for dashboard
- test dashboard rendering with case-insensitive roles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b97a820fac832eb56ba816ca5b3c61