### PR TITLE
chore: bypass login on localhost

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,11 @@
   <title>Login</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/styles.css" />
+  <script>
+    if (['localhost', '127.0.0.1'].includes(window.location.hostname)) {
+      window.location.href = 'dashboard.html';
+    }
+  </script>
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center bg-gray-100">
   <header class="mb-4">

--- a/public/js/check-auth.js
+++ b/public/js/check-auth.js
@@ -3,6 +3,8 @@ import { onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/
 import { doc, getDoc } from "https://www.gstatic.com/firebasejs/10.4.0/firebase-firestore.js";
 import { showToast } from './toast.js';
 
+const IS_LOCAL = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+
 const MODULES = [
   { id: 'financeiro', label: 'Financeiro', url: 'modules/financeiro/index.html' },
   { id: 'suprimentos-logistica', label: 'Suprimentos / Logística', url: 'modules/suprimentos-logistica/index.html' },
@@ -60,6 +62,13 @@ function renderDashboard(role) {
 
 onAuthStateChanged(auth, async (user) => {
   if (!user) {
+    if (IS_LOCAL) {
+      const moduleId = document.body.dataset.module;
+      if (!moduleId) {
+        renderDashboard('admin');
+      }
+      return;
+    }
     window.location.href = 'index.html';
     return;
   }


### PR DESCRIPTION
## Summary
- skip login and permission checks when running on localhost
- auto-redirect to dashboard when accessing login page locally

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97a089f1c832e9e29aefde6c12593